### PR TITLE
[io-kafka] Do not seek to negative offsets.

### DIFF
--- a/direct/io-kafka/src/main/java/cz/o2/proxima/direct/kafka/Utils.java
+++ b/direct/io-kafka/src/main/java/cz/o2/proxima/direct/kafka/Utils.java
@@ -47,7 +47,9 @@ class Utils {
         o -> {
           TopicOffset to = (TopicOffset) o;
           TopicPartition tp = new TopicPartition(topic, o.getPartition().getId());
-          consumer.seek(tp, to.getOffset());
+          if (to.getOffset() >= 0L) {
+            consumer.seek(tp, to.getOffset());
+          }
         });
   }
 


### PR DESCRIPTION
hotfix for empty topics
```
2020-03-05 16:20:53,744 ERROR cz.o2.proxima.direct.kafka.KafkaLogReader                     - Error processing consumer null
java.lang.IllegalArgumentException: seek offset must not be a negative number
	at cz.o2.proxima.kafka.shaded.org.apache.kafka.clients.consumer.KafkaConsumer.seek(KafkaConsumer.java:1560)
	at cz.o2.proxima.direct.kafka.Utils.lambda$seekToOffsets$0(Utils.java:50)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at cz.o2.proxima.direct.kafka.Utils.seekToOffsets(Utils.java:46)
	at cz.o2.proxima.direct.kafka.KafkaLogReader.createConsumer(KafkaLogReader.java:633)
	at cz.o2.proxima.direct.kafka.KafkaLogReader.lambda$submitConsumerWithObserver$4(KafkaLogReader.java:342)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```